### PR TITLE
add id to user profile

### DIFF
--- a/lib/passport-mailchimp/strategy.js
+++ b/lib/passport-mailchimp/strategy.js
@@ -70,7 +70,11 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       var json = JSON.parse(body);
 
       var profile = { provider: 'mailchimp' };
-      profile.id = json.login && json.login.login_id
+      
+      if (json.login && json.login.login_id) {
+        profile.id = json.login.login_id
+      }
+      
       profile.accessToken = accessToken;
       profile.api_endpoint = json.api_endpoint;
       profile.login_url = json.login_url;

--- a/lib/passport-mailchimp/strategy.js
+++ b/lib/passport-mailchimp/strategy.js
@@ -70,6 +70,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       var json = JSON.parse(body);
 
       var profile = { provider: 'mailchimp' };
+      profile.id = json.login && json.login.login_id
       profile.accessToken = accessToken;
       profile.api_endpoint = json.api_endpoint;
       profile.login_url = json.login_url;


### PR DESCRIPTION
It's pretty standard for passport strategies to provide at least the `id` field in the profile.